### PR TITLE
Translation Update

### DIFF
--- a/data/languages.yml
+++ b/data/languages.yml
@@ -6,7 +6,7 @@
 - name: "Russian"
   lessons:
     total: 20
-    complete: 14
+    complete: 16
 
 - name: "Spanish"
   lessons:
@@ -16,4 +16,4 @@
 - name: "Ukrainian (Revision)"
   lessons:
     total: 20
-    complete: 3
+    complete: 4

--- a/data/languages.yml
+++ b/data/languages.yml
@@ -8,7 +8,7 @@
     total: 20
     complete: 16
 
-- name: "Spanish"
+- name: "Spanish*"
   lessons:
     total: 20
     complete: 20

--- a/source/assets/stylesheets/partials/_progress-bar.scss
+++ b/source/assets/stylesheets/partials/_progress-bar.scss
@@ -40,3 +40,11 @@
   from {width: 0%; }
   to {width: 100%;}
 }
+
+.translation-status-notes {
+  margin-top: $base-spacing;
+
+  p {
+    font-size: $base-font-size / 1.7;
+  }
+}

--- a/source/translations.html.haml
+++ b/source/translations.html.haml
@@ -11,3 +11,7 @@ title: Translations
 
   - data.languages.each do |language|
     = partial "partials/progress-bar", locals: { language: language }
+
+  %section.translation-status-notes
+    %p
+      * This translation is now being proofed and edited.


### PR DESCRIPTION
In addition to updating lesson counts for Russian/Ukrainian, this PR also adds a footnote explaining that Spanish is being proofed and edited. Said footnote can easily be used for Russian or other languages as needed.